### PR TITLE
Update dbt models for v1.1.0

### DIFF
--- a/dbt_artifacts_models/Makefile
+++ b/dbt_artifacts_models/Makefile
@@ -3,16 +3,16 @@ setup:
 	dbt deps
 
 build:
-	dbt build --profiles-dir ./profiles --selector dbt-1.0
+	dbt build --profiles-dir ./profiles --selector dbt-1.1
 
 run:
-	dbt run --profiles-dir ./profiles --selector dbt-1.0
+	dbt run --profiles-dir ./profiles --selector dbt-1.1
 
 compile:
 	dbt compile --profiles-dir ./profiles
 
 test:
-	dbt test --profiles-dir profiles/ --selector dbt-1.0
+	dbt test --profiles-dir profiles/ --selector dbt-1.1
 
 docs-generate:
 	dbt docs generate --profiles-dir profiles/

--- a/dbt_artifacts_models/models/sources/v5/manifest_v5.yml
+++ b/dbt_artifacts_models/models/sources/v5/manifest_v5.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+
+sources:
+  - name: "{{ var('dbt_artifacts_loader')['dataset'] }}"
+    database: "{{ var('dbt_artifacts_loader')['project'] }}"
+    tables:
+      - name: manifest_v5
+        identifier: manifest_v5
+
+        columns:
+          - name: loaded_at
+            tests:
+              - not_null

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_generic_test_node_v5/parsed_generic_test_node_v5.sql
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_generic_test_node_v5/parsed_generic_test_node_v5.sql
@@ -1,0 +1,57 @@
+{% set project = var('dbt_artifacts_loader')['project'] %}
+{% set dataset = var('dbt_artifacts_loader')['dataset'] %}
+
+{{
+  config(
+    enabled=true,
+    full_refresh=none,
+    materialized="view",
+    database=project,
+    schema=dataset,
+    alias="parsed_generic_test_node_v5",
+    persist_docs={"relation": true, "columns": true},
+    labels={
+      "modeled_by": "dbt",
+      "app": "dbt-artifacts-loader",
+     },
+  )
+}}
+
+WITH generic_tests AS (
+  SELECT
+    t.* EXCEPT(depends_on),
+    depends_on_node,
+    depends_on_macro,
+  FROM (
+      SELECT
+        loaded_at AS loaded_at,
+        metadata AS metadata,
+        node.key AS key,
+        node.value.ParsedGenericTestNode.*,
+      FROM {{ source(var('dbt_artifacts_loader')['dataset'], 'manifest_v5') }}
+            , UNNEST(nodes) AS node
+  ) AS t
+  CROSS JOIN UNNEST(depends_on.nodes.value) AS depends_on_node
+  CROSS JOIN UNNEST(depends_on.macros.value) AS depends_on_macro
+)
+, generic_tests_with_models AS (
+  SELECT
+    generic_tests.*,
+    (SELECT AS STRUCT models.*) AS depends_on_model,
+  FROM generic_tests AS generic_tests
+  LEFT OUTER JOIN {{ ref("parsed_model_node_v5") }} AS models
+    ON generic_tests.metadata.invocation_id = models.metadata.invocation_id
+        AND generic_tests.depends_on_node = models.unique_id
+)
+, remove_duplicates AS (
+  SELECT
+    ROW_NUMBER() OVER (PARTITION BY metadata.invocation_id, unique_id ORDER BY metadata.generated_at DESC) AS rank,
+    *
+  FROM generic_tests_with_models
+  WHERE unique_id IS NOT NULL
+)
+
+SELECT
+  * EXCEPT(rank)
+FROM remove_duplicates
+WHERE rank = 1

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_generic_test_node_v5/schema.yml
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_generic_test_node_v5/schema.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+models:
+  - name: parsed_generic_test_node_v5
+    description: |
+      This is a table to expand `manifest_v5.node.value.ParsedGenericTestNode`.
+      The table exclude duplicates.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - metadata.invocation_id
+            - unique_id
+
+    columns:
+      - name: metadata.invocation_id
+        description: "invocation ID"
+        tests:
+          - not_null
+      - name: unique_id
+        description: "unique ID"
+        tests:
+          - not_null

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_model_node_v5/parsed_model_node_v5.sql
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_model_node_v5/parsed_model_node_v5.sql
@@ -1,0 +1,40 @@
+{% set project = var('dbt_artifacts_loader')['project'] %}
+{% set dataset = var('dbt_artifacts_loader')['dataset'] %}
+
+{{
+  config(
+    enabled=true,
+    full_refresh=none,
+    materialized="view",
+    database=project,
+    schema=dataset,
+    alias="parsed_model_node_v5",
+    persist_docs={"relation": true, "columns": true},
+    labels={
+      "modeled_by": "dbt",
+      "app": "dbt-artifacts-loader",
+     },
+  )
+}}
+
+WITH expanded_artifacts AS (
+  SELECT
+    loaded_at AS loaded_at,
+    metadata AS metadata,
+    node.key AS key,
+    node.value.ParsedModelNode.*,
+  FROM {{ source(var('dbt_artifacts_loader')['dataset'], 'manifest_v5') }}
+        , UNNEST(nodes) AS node
+)
+, remove_duplicates AS (
+  SELECT
+    ROW_NUMBER() OVER (PARTITION BY metadata.invocation_id, unique_id ORDER BY metadata.generated_at DESC) AS rank,
+    *
+  FROM expanded_artifacts
+  WHERE unique_id IS NOT NULL
+)
+
+SELECT
+  * EXCEPT(rank)
+FROM remove_duplicates
+WHERE rank = 1

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_model_node_v5/schema.yml
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_model_node_v5/schema.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+models:
+  - name: parsed_model_node_v5
+    description: |
+      This is a table to expand `manifest_v5.node.value.ParsedModelNode`.
+      The table exclude duplicates.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - metadata.invocation_id
+            - unique_id
+
+    columns:
+      - name: metadata.invocation_id
+        description: "invocation ID"
+        tests:
+          - not_null
+      - name: unique_id
+        description: "unique ID"
+        tests:
+          - not_null

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_singular_test_node_v5/parsed_singular_test_node_v5.sql
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_singular_test_node_v5/parsed_singular_test_node_v5.sql
@@ -1,0 +1,57 @@
+{% set project = var('dbt_artifacts_loader')['project'] %}
+{% set dataset = var('dbt_artifacts_loader')['dataset'] %}
+
+{{
+  config(
+    enabled=true,
+    full_refresh=none,
+    materialized="view",
+    database=project,
+    schema=dataset,
+    alias="parsed_singular_test_node_v5",
+    persist_docs={"relation": true, "columns": true},
+    labels={
+      "modeled_by": "dbt",
+      "app": "dbt-artifacts-loader",
+     },
+  )
+}}
+
+WITH singular_tests AS (
+  SELECT
+    s.* EXCEPT(depends_on),
+    depends_on_node,
+    depends_on_macro,
+  FROM (
+      SELECT
+        loaded_at AS loaded_at,
+        metadata AS metadata,
+        node.key AS key,
+        node.value.ParsedSingularTestNode.*,
+      FROM {{ source(var('dbt_artifacts_loader')['dataset'], 'manifest_v5') }}
+            , UNNEST(nodes) AS node
+  ) AS s
+  CROSS JOIN UNNEST(depends_on.nodes.value) AS depends_on_node
+  CROSS JOIN UNNEST(depends_on.macros.value) AS depends_on_macro
+)
+, singular_tests_with_models AS (
+  SELECT
+    singular_tests.*,
+    (SELECT AS STRUCT models.*) AS depends_on_model,
+  FROM singular_tests AS singular_tests
+  LEFT OUTER JOIN {{ ref("parsed_model_node_v5") }} AS models
+    ON singular_tests.metadata.invocation_id = models.metadata.invocation_id
+        AND singular_tests.depends_on_node = models.unique_id
+)
+, remove_duplicates AS (
+  SELECT
+    ROW_NUMBER() OVER (PARTITION BY metadata.invocation_id, unique_id ORDER BY metadata.generated_at DESC) AS rank,
+    *
+  FROM singular_tests_with_models
+  WHERE unique_id IS NOT NULL
+)
+
+SELECT
+  * EXCEPT(rank)
+FROM remove_duplicates
+WHERE rank = 1

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_singular_test_node_v5/schema.yml
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_singular_test_node_v5/schema.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+models:
+  - name: parsed_singular_test_node_v5
+    description: |
+      This is a table to expand `manifest_v5.node.value.ParsedSingularTestNode`.
+      The table exclude duplicates.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - metadata.invocation_id
+            - unique_id
+
+    columns:
+      - name: metadata.invocation_id
+        description: "invocation ID"
+        tests:
+          - not_null
+      - name: unique_id
+        description: "unique ID"
+        tests:
+          - not_null

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_snapshot_node_v5/parsed_snapshot_node_v5.sql
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_snapshot_node_v5/parsed_snapshot_node_v5.sql
@@ -1,0 +1,57 @@
+{% set project = var('dbt_artifacts_loader')['project'] %}
+{% set dataset = var('dbt_artifacts_loader')['dataset'] %}
+
+{{
+  config(
+    enabled=true,
+    full_refresh=none,
+    materialized="view",
+    database=project,
+    schema=dataset,
+    alias="parsed_snapshot_node_v5",
+    persist_docs={"relation": true, "columns": true},
+    labels={
+      "modeled_by": "dbt",
+      "app": "dbt-artifacts-loader",
+     },
+  )
+}}
+
+WITH snapshots AS (
+  SELECT
+    s.* EXCEPT(depends_on),
+    depends_on_node,
+    depends_on_macro,
+  FROM (
+      SELECT
+        loaded_at AS loaded_at,
+        metadata AS metadata,
+        node.key AS key,
+        node.value.ParsedSnapshotNode.*,
+      FROM {{ source(var('dbt_artifacts_loader')['dataset'], 'manifest_v5') }}
+            , UNNEST(nodes) AS node
+  ) AS s
+  CROSS JOIN UNNEST(depends_on.nodes.value) AS depends_on_node
+  CROSS JOIN UNNEST(depends_on.macros.value) AS depends_on_macro
+)
+, snapshots_with_models AS (
+  SELECT
+    snapshots.*,
+    (SELECT AS STRUCT models.*) AS depends_on_model,
+  FROM snapshots AS snapshots
+  LEFT OUTER JOIN {{ ref("parsed_model_node_v5") }} AS models
+    ON snapshots.metadata.invocation_id = models.metadata.invocation_id
+        AND snapshots.depends_on_node = models.unique_id
+)
+, remove_duplicates AS (
+  SELECT
+    ROW_NUMBER() OVER (PARTITION BY metadata.invocation_id, unique_id ORDER BY metadata.generated_at DESC) AS rank,
+    *
+  FROM snapshots_with_models
+  WHERE unique_id IS NOT NULL
+)
+
+SELECT
+  * EXCEPT(rank)
+FROM remove_duplicates
+WHERE rank = 1

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_snapshot_node_v5/schema.yml
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/parsed_snapshot_node_v5/schema.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+models:
+  - name: parsed_snapshot_node_v5
+    description: |
+      This is a table to expand `manifest_v5.node.value.ParsedSnapshotNode`.
+      The table exclude duplicates.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - metadata.invocation_id
+            - unique_id
+
+    columns:
+      - name: metadata.invocation_id
+        description: "invocation ID"
+        tests:
+          - not_null
+      - name: unique_id
+        description: "unique ID"
+        tests:
+          - not_null

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/source_manifests_v5/schema.yml
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/source_manifests_v5/schema.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+models:
+  - name: source_manifests_v5
+    description: |
+      This is a table to expand `manifest_v5.sources.value`.
+      The table exclude duplicates.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - metadata.invocation_id
+            - unique_id
+
+    columns:
+      - name: metadata.invocation_id
+        description: "invocation ID"
+        tests:
+          - not_null
+      - name: unique_id
+        description: "unique ID"
+        tests:
+          - not_null

--- a/dbt_artifacts_models/models/staging/v5/manifest_v5/source_manifests_v5/source_manifests_v5.sql
+++ b/dbt_artifacts_models/models/staging/v5/manifest_v5/source_manifests_v5/source_manifests_v5.sql
@@ -1,0 +1,40 @@
+{% set project = var('dbt_artifacts_loader')['project'] %}
+{% set dataset = var('dbt_artifacts_loader')['dataset'] %}
+
+{{
+  config(
+    enabled=true,
+    full_refresh=none,
+    materialized="view",
+    database=project,
+    schema=dataset,
+    alias="source_manifests_v5",
+    persist_docs={"relation": true, "columns": true},
+    labels={
+      "modeled_by": "dbt",
+      "app": "dbt-artifacts-loader",
+     },
+  )
+}}
+
+WITH expanded_artifacts AS (
+  SELECT
+    loaded_at AS loaded_at,
+    metadata AS metadata,
+    source.key AS key,
+    source.value.*
+  FROM {{ source(var('dbt_artifacts_loader')['dataset'], 'manifest_v5') }}
+        , UNNEST(sources) AS source
+)
+, remove_duplicates AS (
+  SELECT
+    ROW_NUMBER() OVER (PARTITION BY metadata.invocation_id, unique_id ORDER BY metadata.generated_at DESC) AS rank,
+    *
+  FROM expanded_artifacts
+  WHERE unique_id IS NOT NULL
+)
+
+SELECT
+  * EXCEPT(rank)
+FROM remove_duplicates
+WHERE rank = 1

--- a/dbt_artifacts_models/selectors.yml
+++ b/dbt_artifacts_models/selectors.yml
@@ -39,3 +39,23 @@ selectors:
         - "models/marts/v4/manifest_v4/*"
         - "models/marts/v4/run_results_v4/*"
         - "models/marts/v1/catalog_v1/*"
+
+  # For dbt==1.1
+  - name: dbt-1.1
+    definition:
+      union:
+        # Sources
+        - "models/sources/v3/sources_v3.yml"
+        - "models/sources/v5/manifest_v5.yml"
+        - "models/sources/v4/run_results_v4.yml"
+        - "models/sources/v1/catalog_v1.yml"
+        # staging
+        - "models/staging/v3/sources_v3/*"
+        - "models/staging/v5/manifest_v5/*"
+        - "models/staging/v4/run_results_v4/*"
+        - "models/staging/v1/catalog_v1/*"
+        # mart
+        - "models/marts/v3/sources_v3/*"
+        - "models/marts/v5/manifest_v5/*"
+        - "models/marts/v4/run_results_v4/*"
+        - "models/marts/v1/catalog_v1/*"


### PR DESCRIPTION

```
dbt build --profiles-dir ./profiles --selector dbt-1.1
02:34:37  Running with dbt=1.1.0
02:34:40  Found 67 models, 262 tests, 0 snapshots, 0 analyses, 379 macros, 0 operations, 0 seed files, 13 sources, 0 exposures, 0 metrics
02:34:40  
02:34:42  Concurrency: 20 threads (target='dev')
02:34:42  
02:34:42  1 of 80 START test source_not_null_dbt_artifacts_catalog_v1_loaded_at .......... [RUN]
02:34:42  2 of 80 START test source_not_null_dbt_artifacts_manifest_v5_loaded_at ......... [RUN]
02:34:42  3 of 80 START test source_not_null_dbt_artifacts_run_results_v4_loaded_at ...... [RUN]
02:34:42  4 of 80 START test source_not_null_dbt_artifacts_sources_v3_loaded_at .......... [RUN]
02:34:43  4 of 80 PASS source_not_null_dbt_artifacts_sources_v3_loaded_at ................ [[32mPASS[0m in 0.86s]
02:34:43  5 of 80 START view model dbt_artifacts.source_freshness_output_v3 .............. [RUN]
02:34:43  6 of 80 START view model dbt_artifacts.source_freshness_runtime_error_v3 ....... [RUN]
02:34:43  3 of 80 PASS source_not_null_dbt_artifacts_run_results_v4_loaded_at ............ [[32mPASS[0m in 0.94s]
02:34:43  7 of 80 START view model dbt_artifacts.expanded_run_results_v4 ................. [RUN]
02:34:43  1 of 80 PASS source_not_null_dbt_artifacts_catalog_v1_loaded_at ................ [[32mPASS[0m in 0.95s]
02:34:43  2 of 80 PASS source_not_null_dbt_artifacts_manifest_v5_loaded_at ............... [[32mPASS[0m in 1.04s]
02:34:43  8 of 80 START view model dbt_artifacts.parsed_model_node_v5 .................... [RUN]
02:34:43  9 of 80 START view model dbt_artifacts.source_manifests_v5 ..................... [RUN]
02:34:44  6 of 80 OK created view model dbt_artifacts.source_freshness_runtime_error_v3 .. [[32mOK[0m in 0.89s]
02:34:44  10 of 80 START test dbt_utils_unique_combination_of_columns_source_freshness_runtime_error_v3_invocation_id__unique_id  [RUN]
02:34:44  11 of 80 START test not_null_source_freshness_runtime_error_v3_invocation_id ... [RUN]
02:34:44  12 of 80 START test not_null_source_freshness_runtime_error_v3_unique_id ....... [RUN]
02:34:44  7 of 80 OK created view model dbt_artifacts.expanded_run_results_v4 ............ [[32mOK[0m in 0.99s]
02:34:44  13 of 80 START test dbt_utils_unique_combination_of_columns_expanded_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:44  14 of 80 START test not_null_expanded_run_results_v4_metadata_invocation_id .... [RUN]
02:34:44  15 of 80 START test not_null_expanded_run_results_v4_unique_id ................. [RUN]
02:34:44  5 of 80 OK created view model dbt_artifacts.source_freshness_output_v3 ......... [[32mOK[0m in 1.20s]
02:34:44  16 of 80 START test dbt_utils_unique_combination_of_columns_source_freshness_output_v3_invocation_id__unique_id  [RUN]
02:34:44  17 of 80 START test not_null_source_freshness_output_v3_invocation_id .......... [RUN]
02:34:44  18 of 80 START test not_null_source_freshness_output_v3_unique_id .............. [RUN]
02:34:44  9 of 80 OK created view model dbt_artifacts.source_manifests_v5 ................ [[32mOK[0m in 1.13s]
02:34:44  19 of 80 START test dbt_utils_unique_combination_of_columns_source_manifests_v5_metadata_invocation_id__unique_id  [RUN]
02:34:44  20 of 80 START test not_null_source_manifests_v5_metadata_invocation_id ........ [RUN]
02:34:44  21 of 80 START test not_null_source_manifests_v5_unique_id ..................... [RUN]
02:34:44  8 of 80 OK created view model dbt_artifacts.parsed_model_node_v5 ............... [[32mOK[0m in 1.16s]
02:34:44  22 of 80 START test dbt_utils_unique_combination_of_columns_parsed_model_node_v5_metadata_invocation_id__unique_id  [RUN]
02:34:44  23 of 80 START test not_null_parsed_model_node_v5_metadata_invocation_id ....... [RUN]
02:34:44  24 of 80 START test not_null_parsed_model_node_v5_unique_id .................... [RUN]
02:34:45  10 of 80 PASS dbt_utils_unique_combination_of_columns_source_freshness_runtime_error_v3_invocation_id__unique_id  [[32mPASS[0m in 0.96s]
02:34:45  12 of 80 PASS not_null_source_freshness_runtime_error_v3_unique_id ............. [[32mPASS[0m in 0.97s]
02:34:45  11 of 80 PASS not_null_source_freshness_runtime_error_v3_invocation_id ......... [[32mPASS[0m in 1.08s]
02:34:45  14 of 80 PASS not_null_expanded_run_results_v4_metadata_invocation_id .......... [[32mPASS[0m in 0.95s]
02:34:45  16 of 80 PASS dbt_utils_unique_combination_of_columns_source_freshness_output_v3_invocation_id__unique_id  [[32mPASS[0m in 0.84s]
02:34:45  17 of 80 PASS not_null_source_freshness_output_v3_invocation_id ................ [[32mPASS[0m in 0.87s]
02:34:45  18 of 80 PASS not_null_source_freshness_output_v3_unique_id .................... [[32mPASS[0m in 0.96s]
02:34:45  13 of 80 PASS dbt_utils_unique_combination_of_columns_expanded_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 1.10s]
02:34:45  15 of 80 PASS not_null_expanded_run_results_v4_unique_id ....................... [[32mPASS[0m in 1.13s]
02:34:45  25 of 80 START view model dbt_artifacts.generic_test_run_results_v4 ............ [RUN]
02:34:45  26 of 80 START view model dbt_artifacts.model_run_results_v4 ................... [RUN]
02:34:45  27 of 80 START view model dbt_artifacts.singular_test_run_results_v4 ........... [RUN]
02:34:45  28 of 80 START view model dbt_artifacts.snapshot_run_results_v4 ................ [RUN]
02:34:45  23 of 80 PASS not_null_parsed_model_node_v5_metadata_invocation_id ............. [[32mPASS[0m in 1.06s]
02:34:45  19 of 80 PASS dbt_utils_unique_combination_of_columns_source_manifests_v5_metadata_invocation_id__unique_id  [[32mPASS[0m in 1.11s]
02:34:45  24 of 80 PASS not_null_parsed_model_node_v5_unique_id .......................... [[32mPASS[0m in 1.11s]
02:34:45  22 of 80 PASS dbt_utils_unique_combination_of_columns_parsed_model_node_v5_metadata_invocation_id__unique_id  [[32mPASS[0m in 1.12s]
02:34:45  29 of 80 START view model dbt_artifacts.parsed_generic_test_node_v5 ............ [RUN]
02:34:45  30 of 80 START view model dbt_artifacts.parsed_singular_test_node_v5 ........... [RUN]
02:34:45  31 of 80 START view model dbt_artifacts.parsed_snapshot_node_v5 ................ [RUN]
02:34:45  21 of 80 PASS not_null_source_manifests_v5_unique_id ........................... [[32mPASS[0m in 1.19s]
02:34:45  20 of 80 PASS not_null_source_manifests_v5_metadata_invocation_id .............. [[32mPASS[0m in 1.20s]
02:34:46  25 of 80 OK created view model dbt_artifacts.generic_test_run_results_v4 ....... [[32mOK[0m in 1.07s]
02:34:46  32 of 80 START test accepted_values_generic_test_run_results_v4_timing_name__execute  [RUN]
02:34:46  33 of 80 START test dbt_utils_unique_combination_of_columns_generic_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:46  34 of 80 START test not_null_generic_test_run_results_v4_metadata_invocation_id  [RUN]
02:34:46  35 of 80 START test not_null_generic_test_run_results_v4_unique_id ............. [RUN]
02:34:46  28 of 80 OK created view model dbt_artifacts.snapshot_run_results_v4 ........... [[32mOK[0m in 1.12s]
02:34:46  26 of 80 OK created view model dbt_artifacts.model_run_results_v4 .............. [[32mOK[0m in 1.12s]
02:34:46  27 of 80 OK created view model dbt_artifacts.singular_test_run_results_v4 ...... [[32mOK[0m in 1.12s]
02:34:46  36 of 80 START test accepted_values_snapshot_run_results_v4_timing_name__execute  [RUN]
02:34:46  37 of 80 START test dbt_utils_unique_combination_of_columns_snapshot_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:46  38 of 80 START test not_null_snapshot_run_results_v4_metadata_invocation_id .... [RUN]
02:34:46  39 of 80 START test not_null_snapshot_run_results_v4_unique_id ................. [RUN]
02:34:46  40 of 80 START test accepted_values_model_run_results_v4_timing_name__execute .. [RUN]
02:34:46  41 of 80 START test accepted_values_singular_test_run_results_v4_timing_name__execute  [RUN]
02:34:46  42 of 80 START test dbt_utils_unique_combination_of_columns_model_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:46  43 of 80 START test dbt_utils_unique_combination_of_columns_singular_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:46  44 of 80 START test not_null_model_run_results_v4_metadata_invocation_id ....... [RUN]
02:34:46  45 of 80 START test not_null_model_run_results_v4_unique_id .................... [RUN]
02:34:46  46 of 80 START test not_null_singular_test_run_results_v4_metadata_invocation_id  [RUN]
02:34:46  47 of 80 START test not_null_singular_test_run_results_v4_unique_id ............ [RUN]
02:34:46  30 of 80 OK created view model dbt_artifacts.parsed_singular_test_node_v5 ...... [[32mOK[0m in 1.00s]
02:34:46  48 of 80 START test dbt_utils_unique_combination_of_columns_parsed_singular_test_node_v5_metadata_invocation_id__unique_id  [RUN]
02:34:46  49 of 80 START test not_null_parsed_singular_test_node_v5_metadata_invocation_id  [RUN]
02:34:46  31 of 80 OK created view model dbt_artifacts.parsed_snapshot_node_v5 ........... [[32mOK[0m in 1.18s]
02:34:46  50 of 80 START test not_null_parsed_singular_test_node_v5_unique_id ............ [RUN]
02:34:47  29 of 80 OK created view model dbt_artifacts.parsed_generic_test_node_v5 ....... [[32mOK[0m in 1.31s]
02:34:47  51 of 80 START test dbt_utils_unique_combination_of_columns_parsed_snapshot_node_v5_metadata_invocation_id__unique_id  [RUN]
02:34:48  35 of 80 PASS not_null_generic_test_run_results_v4_unique_id ................... [[32mPASS[0m in 1.46s]
02:34:48  52 of 80 START test not_null_parsed_snapshot_node_v5_metadata_invocation_id .... [RUN]
02:34:48  34 of 80 PASS not_null_generic_test_run_results_v4_metadata_invocation_id ...... [[32mPASS[0m in 1.56s]
02:34:48  53 of 80 START test not_null_parsed_snapshot_node_v5_unique_id ................. [RUN]
02:34:48  44 of 80 PASS not_null_model_run_results_v4_metadata_invocation_id ............. [[32mPASS[0m in 1.49s]
02:34:48  33 of 80 PASS dbt_utils_unique_combination_of_columns_generic_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 1.59s]
02:34:48  54 of 80 START test dbt_utils_unique_combination_of_columns_parsed_generic_test_node_v5_metadata_invocation_id__unique_id  [RUN]
02:34:48  55 of 80 START test not_null_parsed_generic_test_node_v5_metadata_invocation_id  [RUN]
02:34:48  32 of 80 PASS accepted_values_generic_test_run_results_v4_timing_name__execute . [[32mPASS[0m in 1.74s]
02:34:48  56 of 80 START test not_null_parsed_generic_test_node_v5_unique_id ............. [RUN]
02:34:48  36 of 80 PASS accepted_values_snapshot_run_results_v4_timing_name__execute ..... [[32mPASS[0m in 1.72s]
02:34:48  57 of 80 START view model dbt_artifacts.last_generic_test_run_results_v4 ....... [RUN]
02:34:48  40 of 80 PASS accepted_values_model_run_results_v4_timing_name__execute ........ [[32mPASS[0m in 1.80s]
02:34:48  43 of 80 PASS dbt_utils_unique_combination_of_columns_singular_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 1.84s]
02:34:48  46 of 80 PASS not_null_singular_test_run_results_v4_metadata_invocation_id ..... [[32mPASS[0m in 1.90s]
02:34:48  37 of 80 PASS dbt_utils_unique_combination_of_columns_snapshot_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 1.97s]
02:34:48  47 of 80 PASS not_null_singular_test_run_results_v4_unique_id .................. [[32mPASS[0m in 2.02s]
02:34:48  38 of 80 PASS not_null_snapshot_run_results_v4_metadata_invocation_id .......... [[32mPASS[0m in 2.04s]
02:34:48  49 of 80 PASS not_null_parsed_singular_test_node_v5_metadata_invocation_id ..... [[32mPASS[0m in 1.88s]
02:34:48  42 of 80 PASS dbt_utils_unique_combination_of_columns_model_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 2.04s]
02:34:48  50 of 80 PASS not_null_parsed_singular_test_node_v5_unique_id .................. [[32mPASS[0m in 1.75s]
02:34:48  48 of 80 PASS dbt_utils_unique_combination_of_columns_parsed_singular_test_node_v5_metadata_invocation_id__unique_id  [[32mPASS[0m in 1.93s]
02:34:48  39 of 80 PASS not_null_snapshot_run_results_v4_unique_id ....................... [[32mPASS[0m in 2.13s]
02:34:48  45 of 80 PASS not_null_model_run_results_v4_unique_id .......................... [[32mPASS[0m in 2.13s]
02:34:48  58 of 80 START view model dbt_artifacts.last_snapshot_run_results_v4 ........... [RUN]
02:34:48  59 of 80 START view model dbt_artifacts.last_model_run_results_v4 .............. [RUN]
02:34:48  41 of 80 PASS accepted_values_singular_test_run_results_v4_timing_name__execute  [[32mPASS[0m in 2.29s]
02:34:48  60 of 80 START view model dbt_artifacts.last_singular_test_run_results_v4 ...... [RUN]
02:34:48  51 of 80 PASS dbt_utils_unique_combination_of_columns_parsed_snapshot_node_v5_metadata_invocation_id__unique_id  [[32mPASS[0m in 1.91s]
02:34:49  52 of 80 PASS not_null_parsed_snapshot_node_v5_metadata_invocation_id .......... [[32mPASS[0m in 1.14s]
02:34:49  55 of 80 PASS not_null_parsed_generic_test_node_v5_metadata_invocation_id ...... [[32mPASS[0m in 1.17s]
02:34:49  53 of 80 PASS not_null_parsed_snapshot_node_v5_unique_id ....................... [[32mPASS[0m in 1.22s]
02:34:49  54 of 80 PASS dbt_utils_unique_combination_of_columns_parsed_generic_test_node_v5_metadata_invocation_id__unique_id  [[32mPASS[0m in 1.21s]
02:34:49  57 of 80 OK created view model dbt_artifacts.last_generic_test_run_results_v4 .. [[32mOK[0m in 1.09s]
02:34:49  61 of 80 START test accepted_values_last_generic_test_run_results_v4_timing_name__execute  [RUN]
02:34:49  62 of 80 START test dbt_utils_unique_combination_of_columns_last_generic_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:49  63 of 80 START test not_null_last_generic_test_run_results_v4_metadata_invocation_id  [RUN]
02:34:49  64 of 80 START test not_null_last_generic_test_run_results_v4_unique_id ........ [RUN]
02:34:49  65 of 80 START test unique_last_generic_test_run_results_v4_unique_id .......... [RUN]
02:34:49  56 of 80 PASS not_null_parsed_generic_test_node_v5_unique_id ................... [[32mPASS[0m in 1.26s]
02:34:49  59 of 80 OK created view model dbt_artifacts.last_model_run_results_v4 ......... [[32mOK[0m in 1.04s]
02:34:49  66 of 80 START test accepted_values_last_model_run_results_v4_timing_name__execute  [RUN]
02:34:49  67 of 80 START test dbt_utils_unique_combination_of_columns_last_model_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:49  68 of 80 START test not_null_last_model_run_results_v4_metadata_invocation_id .. [RUN]
02:34:49  69 of 80 START test not_null_last_model_run_results_v4_unique_id ............... [RUN]
02:34:49  70 of 80 START test unique_last_model_run_results_v4_unique_id ................. [RUN]
02:34:49  58 of 80 OK created view model dbt_artifacts.last_snapshot_run_results_v4 ...... [[32mOK[0m in 1.12s]
02:34:49  71 of 80 START test accepted_values_last_snapshot_run_results_v4_timing_name__execute  [RUN]
02:34:49  72 of 80 START test dbt_utils_unique_combination_of_columns_last_snapshot_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:49  73 of 80 START test not_null_last_snapshot_run_results_v4_metadata_invocation_id  [RUN]
02:34:49  74 of 80 START test not_null_last_snapshot_run_results_v4_unique_id ............ [RUN]
02:34:49  75 of 80 START test unique_last_snapshot_run_results_v4_unique_id .............. [RUN]
02:34:50  60 of 80 OK created view model dbt_artifacts.last_singular_test_run_results_v4 . [[32mOK[0m in 1.08s]
02:34:50  76 of 80 START test accepted_values_last_singular_test_run_results_v4_timing_name__execute  [RUN]
02:34:50  77 of 80 START test dbt_utils_unique_combination_of_columns_last_singular_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [RUN]
02:34:50  78 of 80 START test not_null_last_singular_test_run_results_v4_metadata_invocation_id  [RUN]
02:34:50  79 of 80 START test not_null_last_singular_test_run_results_v4_unique_id ....... [RUN]
02:34:50  80 of 80 START test unique_last_singular_test_run_results_v4_unique_id ......... [RUN]
02:34:51  64 of 80 PASS not_null_last_generic_test_run_results_v4_unique_id .............. [[32mPASS[0m in 1.61s]
02:34:51  63 of 80 PASS not_null_last_generic_test_run_results_v4_metadata_invocation_id . [[32mPASS[0m in 1.66s]
02:34:51  62 of 80 PASS dbt_utils_unique_combination_of_columns_last_generic_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 1.72s]
02:34:51  65 of 80 PASS unique_last_generic_test_run_results_v4_unique_id ................ [[32mPASS[0m in 1.72s]
02:34:51  61 of 80 PASS accepted_values_last_generic_test_run_results_v4_timing_name__execute  [[32mPASS[0m in 1.74s]
02:34:51  66 of 80 PASS accepted_values_last_model_run_results_v4_timing_name__execute ... [[32mPASS[0m in 1.71s]
02:34:51  73 of 80 PASS not_null_last_snapshot_run_results_v4_metadata_invocation_id ..... [[32mPASS[0m in 1.65s]
02:34:51  69 of 80 PASS not_null_last_model_run_results_v4_unique_id ..................... [[32mPASS[0m in 1.74s]
02:34:51  68 of 80 PASS not_null_last_model_run_results_v4_metadata_invocation_id ........ [[32mPASS[0m in 1.87s]
02:34:51  72 of 80 PASS dbt_utils_unique_combination_of_columns_last_snapshot_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 1.78s]
02:34:51  71 of 80 PASS accepted_values_last_snapshot_run_results_v4_timing_name__execute  [[32mPASS[0m in 1.96s]
02:34:52  67 of 80 PASS dbt_utils_unique_combination_of_columns_last_model_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 2.23s]
02:34:52  70 of 80 PASS unique_last_model_run_results_v4_unique_id ....................... [[32mPASS[0m in 2.23s]
02:34:52  75 of 80 PASS unique_last_snapshot_run_results_v4_unique_id .................... [[32mPASS[0m in 2.19s]
02:34:52  79 of 80 PASS not_null_last_singular_test_run_results_v4_unique_id ............. [[32mPASS[0m in 2.11s]
02:34:52  74 of 80 PASS not_null_last_snapshot_run_results_v4_unique_id .................. [[32mPASS[0m in 2.29s]
02:34:52  80 of 80 PASS unique_last_singular_test_run_results_v4_unique_id ............... [[32mPASS[0m in 2.20s]
02:34:52  76 of 80 PASS accepted_values_last_singular_test_run_results_v4_timing_name__execute  [[32mPASS[0m in 2.22s]
02:34:52  78 of 80 PASS not_null_last_singular_test_run_results_v4_metadata_invocation_id  [[32mPASS[0m in 2.23s]
02:34:52  77 of 80 PASS dbt_utils_unique_combination_of_columns_last_singular_test_run_results_v4_metadata_invocation_id__unique_id__timing_name  [[32mPASS[0m in 2.46s]
02:34:52  
02:34:52  Finished running 64 tests, 16 view models in 12.23s.
02:34:52  
02:34:52  [32mCompleted successfully[0m
02:34:52  
02:34:52  Done. PASS=80 WARN=0 ERROR=0 SKIP=0 TOTAL=80
```